### PR TITLE
ci: serialize credential-backed tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,12 +10,17 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: tests-shared-account
+  queue: max
+
 jobs:
   vitest:
     name: Vitest (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         node-version: [24, 26]
     steps:

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    fileParallelism: false,
     retry: 2,
     testTimeout: 120_000,
   },


### PR DESCRIPTION
## Summary
- serialize credential-backed Vitest files, Node matrix jobs, and workflow runs
- prevent concurrent GitLab LDAP logins from invalidating the shared CI account session
- preserve both Node 24 and Node 26 coverage without weakening assertions or retries

## Root cause
Concurrent valid GitLab logins with the same account race: one redirects to the authenticated home page while another returns to the sign-in page, causing cookie validation to fail.

## Verification
- npm test (52/52)
- npm run lint
- npm run build
- direct built-package GitLab authentication and cookie validation
- five-lane review: goal, QA, code quality, security, and repository context